### PR TITLE
Let HACS use .zip to enable download counting

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,10 +2,13 @@
   "name": "SENZ WiFi",
   "domains": [
     "climate",
-    "sensor"
+    "sensor",
+    "binary_sensor"
   ],
   "homeassistant": "2021.11.0",
   "iot_class": [
     "Cloud Poll"
-  ]
+  ],
+  "zip_release": true,
+  "filename": "senz.zip"
 }


### PR DESCRIPTION
A Github workflow creates a zipped archive for download by HACS. This will enable download counting.